### PR TITLE
Add Connection header to the HTTP client configuration.

### DIFF
--- a/src/Sdk/Sdk.php
+++ b/src/Sdk/Sdk.php
@@ -59,7 +59,13 @@ class Sdk {
 		}
 
 		try {
-			$session = Client\Client::createSession( $credentials );
+			$options = new Client\ClientOptions();
+			$options->addHeaders(
+				[
+					'Connection' => 'close',
+				]
+			);
+			$session = Client\Client::createSession( $credentials, $options );
 		} catch ( \Exception $exception ) {
 			ShoppingFeedHelper::get_logger()->error(
 				sprintf(


### PR DESCRIPTION
Force connections to be closed after the request has been completed.
Fix "Too many open files" issue for long running script which trigger
a lot of request to ShoppingFeed API.