### PR TITLE
avoid empty string in adress names to avoid conflict with delivery pl…

### DIFF
--- a/src/Orders/Order/Address.php
+++ b/src/Orders/Order/Address.php
@@ -42,11 +42,11 @@ class Address {
 	}
 
 	private function get_first_name() {
-		return ! empty( $this->sf_address['firstName'] ) ? $this->sf_address['firstName'] : '';
+		return ! empty( $this->sf_address['firstName'] ) ? $this->sf_address['firstName'] : '_';
 	}
 
 	private function get_last_name() {
-		return ! empty( $this->sf_address['lastName'] ) ? $this->sf_address['lastName'] : '';
+		return ! empty( $this->sf_address['lastName'] ) ? $this->sf_address['lastName'] : '_';
 	}
 
 	private function get_company() {


### PR DESCRIPTION
Hi ! 

We discover that empty string in adress names cause conflict with delivery plugins during the generation of delivery bill. If firstname or lastname doesn't exists (empty string) the delivery bill is not automatically generated so it inconvenient to generated all the bills manually.

Regards.