### PR TITLE
Add settings to get main parent image

### DIFF
--- a/src/Admin/Options.php
+++ b/src/Admin/Options.php
@@ -940,6 +940,26 @@ class Options {
 			self::SF_FEED_SETTINGS_PAGE,
 			'sf_feed_settings_categories'
 		);
+		
+		// Get main image from parent without have variant in feed
+		add_settings_field(
+			'get_parent_image_if_empty_in_feed',
+			__( 'Set the main image of the parent if the variation is blank', 'shopping-feed' ),
+			function () {
+				?>
+				<label>
+					<input
+						type="checkbox"
+						name="<?php echo esc_attr( sprintf( '%s[get_parent_image_if_empty_in_feed]', self::SF_FEED_OPTIONS ) ); ?>"
+						<?php checked( $this->sf_feed_options['get_parent_image_if_empty_in_feed'], 'on' ); ?>
+					/>
+				</label>
+
+				<?php
+			},
+			self::SF_FEED_SETTINGS_PAGE,
+			'sf_feed_settings_categories'
+		);
 
 		//Identifier Field
 		add_settings_field(

--- a/src/Products/Product.php
+++ b/src/Products/Product.php
@@ -453,6 +453,7 @@ class Product {
 
 		$product                      = new \WC_Product_Variable( $this->id );
 		$show_out_of_stock_variations = $for_feed && ShoppingFeedHelper::show_out_of_stock_products_in_feed();
+		$check_parent_main_image      = ShoppingFeedHelper::check_get_parent_image_if_empty_in_feed();
 		$variations                   = [];
 		foreach ( $product->get_children() as $variation_id ) {
 			$variation = wc_get_product( $variation_id );
@@ -479,6 +480,8 @@ class Product {
 			$variation_data['length']   = $variation->get_length();
 			if ( ! empty( get_the_post_thumbnail_url( $variation->get_id(), 'full' ) ) ) {
 				$variation_data['image_main'] = get_the_post_thumbnail_url( $variation->get_id(), 'full' );
+			} elseif ($check_parent_main_image && ! empty( get_the_post_thumbnail_url( $variation->get_parent_id(), 'full' ) ) ) {
+				$variation_data['image_main'] = get_the_post_thumbnail_url( $variation->get_parent_id(), 'full' );
 			}
 
 			$variation_data['attributes'] = $this->get_variation_attributes( $variation );

--- a/src/ShoppingFeedHelper.php
+++ b/src/ShoppingFeedHelper.php
@@ -263,6 +263,15 @@ XML;
 	}
 
 	/**
+	 * Should the main image of the parent product be collected if the variation image is empty?
+	 *
+	 * @return bool true if you have to make this check, false otherwise.
+	 */
+	public static function check_get_parent_image_if_empty_in_feed() {
+		return 'on' === self::get_sf_feed_options( 'get_parent_image_if_empty_in_feed' );
+	}
+	
+	/**
 	 * Return display mode for category
 	 * @return string
 	 */


### PR DESCRIPTION
When main variation image is empty, not sending main image. With this configuration you can control this behavior

To reproduce the “error”, you can use the `shopping_feed_variation_images` hook.
When you are using this hook and you have not set a main variation image, it causes the main image to be the 1st image in the gallery and not the main image.
If you have size variations and color variations, it causes the color images to have the correct gallery and the size images to have the wrong gallery (because it is the same gallery as the parent).

As there is no hook to control this behavior or the data of the products, I have chosen to add this pull request.
_Logically you can fix this error by adding by hand all the main images to the variations, but this becomes unrealistic when you have many products with many variations._